### PR TITLE
Updated debian, UI can be started again

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,21 @@
-FROM debian:squeeze
+FROM debian:jessie
 
 MAINTAINER info.inspectit@novatec-gmbh.de
 
 ENV INSPECTIT_VERSION 1.6.8.82
 
-RUN apt-get update && apt-get install -y wget unzip libgtk2.0-0 libxtst6 libcanberra-gtk-module xulrunner-1.9.1 \	
-        && apt-get clean \
-        && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-RUN wget ftp://ntftp.novatec-gmbh.de/inspectit/releases/RELEASE.${INSPECTIT_VERSION}/inspectit-linux.gtk.x86_64.zip -qO /opt/inspectit.zip \
-	&& unzip /opt/inspectit.zip \
-	&& rm /opt/inspectit.zip
+# prepare the needed libs
+RUN apt-get update && apt-get install -y wget unzip libgtk2.0-0 libxtst6 libcanberra-gtk-module \	
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-CMD /inspectit/inspectIT
+# download the inspectIT 
+RUN wget https://github.com/inspectIT/inspectIT/releases/download/${INSPECTIT_VERSION}/inspectit-linux.gtk.x86_64-${INSPECTIT_VERSION}.zip -qO /opt/inspectit.zip \
+ && unzip /opt/inspectit.zip \
+ && rm /opt/inspectit.zip
+
+# disable showing of welcome screen
+RUN mkdir -p /inspectit/workspace/.metadata/.plugins/org.eclipse.core.runtime/.settings/ \
+ && printf "eclipse.preferences.version=1\nshowIntro=false\n" > /inspectit/workspace/.metadata/.plugins/org.eclipse.core.runtime/.settings/org.eclipse.ui.prefs
+
+CMD cd /inspectit && ./inspectIT


### PR DESCRIPTION
@inspectit-docker/owners I updated the debian version and now the ui starts. It does not look too good, I am not sure if some extra packages must be downloaded, but at least it works.. I was not able to completely remove the welcome screen showing, I will investigate more to see how to make this work later.

I also removed _xulrunner-1.9.1_ lib as it was not available anymore.

![debian1](https://cloud.githubusercontent.com/assets/10600041/16870663/0b197826-4a83-11e6-9c1d-3fbe3636f597.png)
![debian2](https://cloud.githubusercontent.com/assets/10600041/16870664/0b1a5836-4a83-11e6-98cf-dbfa034ed254.png)
